### PR TITLE
Update demo-sync.php

### DIFF
--- a/examples/demo-sync.php
+++ b/examples/demo-sync.php
@@ -15,7 +15,7 @@ namespace Prooph\EventStoreClient;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$connection = EventStoreAsyncConnectionBuilder::createFromSettingsWithIpEndPoint(
+$connection = EventStoreSyncConnectionBuilder::createFromSettingsWithIpEndPoint(
     new EndPoint('eventstore', 1113)
 );
 


### PR DESCRIPTION
While checking out the examples I noticed that the sync example is using `EventStoreAsyncConnectionBuilder` instead of `EventStoreSyncConnectionBuilder`. That's a bug, right?

Btw why are these classes named builders? With a builder in the name I'd expect some fluent interface to configure it. These classes should be named factories instead imo.