### PR TITLE
Connection factory fixes

### DIFF
--- a/docker/local-3-node-dns-cluster/docker-compose.yml
+++ b/docker/local-3-node-dns-cluster/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   php:
     image: prooph/php:7.2-cli
     volumes:
-      - ./..:/app
+      - ../..:/app
     command: tail -f /dev/null
     networks:
       clusternetwork:

--- a/examples/demo-subscription-with-cluster.php
+++ b/examples/demo-subscription-with-cluster.php
@@ -1,0 +1,104 @@
+<?php
+
+/**
+ * This file is part of `prooph/event-store-client`.
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStoreClient;
+
+use Amp\Loop;
+use Amp\Promise;
+use Amp\Success;
+use Prooph\EventStoreClient\Exception\InvalidOperationException;
+use Prooph\EventStoreClient\Internal\AbstractEventStorePersistentSubscription;
+use Prooph\EventStoreClient\Internal\PersistentSubscriptionCreateResult;
+use Prooph\EventStoreClient\Internal\ResolvedEvent;
+use Throwable;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+Loop::run(function () {
+    $builder = new ConnectionSettingsBuilder();
+    $builder->enableVerboseLogging();
+    $builder->performOnAnyNode();
+    $builder->useConsoleLogger();
+    $builder->setClusterDns('escluster.net');
+    $builder->setClusterGossipPort(2113);
+
+    $connection = EventStoreAsyncConnectionFactory::createFromConnectionString(
+        'ConnectTo=discover://escluster.net:2113',
+        $builder->build(),
+        'dns-cluster-connection'
+    );
+
+    $connection->onConnected(function (): void {
+        echo 'connected' . PHP_EOL;
+    });
+
+    $connection->onClosed(function (): void {
+        echo 'connection closed' . PHP_EOL;
+    });
+
+    yield $connection->connectAsync();
+
+    try {
+        $result = yield $connection->deletePersistentSubscriptionAsync(
+            'foo-bar',
+            'test-persistent-subscription',
+            new UserCredentials('admin', 'changeit')
+        );
+        \var_dump($result);
+    } catch (InvalidOperationException $exception) {
+        echo 'no such subscription exists (yet)' . PHP_EOL;
+    }
+
+    $result = yield $connection->createPersistentSubscriptionAsync(
+        'foo-bar',
+        'test-persistent-subscription',
+        PersistentSubscriptionSettings::default(),
+        new UserCredentials('admin', 'changeit')
+    );
+    \assert($result instanceof PersistentSubscriptionCreateResult);
+
+    \var_dump($result);
+
+    yield $connection->connectToPersistentSubscriptionAsync(
+        'foo-bar',
+        'test-persistent-subscription',
+        new class() implements EventAppearedOnPersistentSubscription {
+            public function __invoke(
+                AbstractEventStorePersistentSubscription $subscription,
+                ResolvedEvent $resolvedEvent,
+                ?int $retryCount = null
+            ): Promise {
+                echo 'incoming event: ' . $resolvedEvent->originalEventNumber() . '@' . $resolvedEvent->originalStreamName() . PHP_EOL;
+                echo 'data: ' . $resolvedEvent->originalEvent()->data() . PHP_EOL;
+
+                return new Success();
+            }
+        },
+        new class() implements PersistentSubscriptionDropped {
+            public function __invoke(
+                AbstractEventStorePersistentSubscription $subscription,
+                SubscriptionDropReason $reason,
+                ?Throwable $exception = null
+            ): void {
+                echo 'dropped with reason: ' . $reason->name() . PHP_EOL;
+
+                if ($exception) {
+                    echo 'ex: ' . $exception->getMessage() . PHP_EOL;
+                }
+            }
+        },
+        10,
+        true,
+        new UserCredentials('admin', 'changeit')
+    );
+});

--- a/examples/demo-subscription-with-dns-cluster.php
+++ b/examples/demo-subscription-with-dns-cluster.php
@@ -26,9 +26,6 @@ require __DIR__ . '/../vendor/autoload.php';
 
 Loop::run(function () {
     $builder = new ConnectionSettingsBuilder();
-    $builder->enableVerboseLogging();
-    $builder->performOnAnyNode();
-    $builder->useConsoleLogger();
     $builder->setClusterDns('escluster.net');
     $builder->setClusterGossipPort(2113);
 

--- a/src/ClusterSettings.php
+++ b/src/ClusterSettings.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Prooph\EventStoreClient;
 
 use Prooph\EventStoreClient\Exception\InvalidArgumentException;
+use Prooph\EventStoreClient\Exception\OutOfRangeException;
 
 /**
  * All times are milliseconds
@@ -27,7 +28,7 @@ class ClusterSettings
     /** @var int */
     private $externalGossipPort;
     /** @var GossipSeed[]|null */
-    private $gossipSeeds;
+    private $gossipSeeds = [];
     /** @var int */
     private $gossipTimeout;
     /** @var bool */
@@ -57,7 +58,9 @@ class ClusterSettings
             $clusterSettings->gossipSeeds[] = $gossipSeed;
         }
 
+        $clusterSettings->clusterDns = '';
         $clusterSettings->maxDiscoverAttempts = $maxDiscoverAttempts;
+        $clusterSettings->externalGossipPort = 0;
         $clusterSettings->gossipTimeout = $gossipTimeout;
         $clusterSettings->preferRandomNode = $preferRandomNode;
 
@@ -72,6 +75,26 @@ class ClusterSettings
         bool $preferRandomNode
     ): self {
         $clusterSettings = new self();
+
+        if (empty($clusterDns)) {
+            throw new InvalidArgumentException(
+                'Cluster DNS cannot be empty'
+            );
+        }
+
+        if ($maxDiscoverAttempts < -1) {
+            throw new OutOfRangeException(\sprintf(
+                'maxDiscoverAttempts value is out of range: %d. Allowed range: [-1, infinity].',
+                $maxDiscoverAttempts
+            ));
+        }
+
+        if ($externalGossipPort < 1) {
+            throw new OutOfRangeException(\sprintf(
+                'externalGossipPort value is out of range: %d. Allowed range: [1, infinity].',
+                $externalGossipPort
+            ));
+        }
 
         $clusterSettings->clusterDns = $clusterDns;
         $clusterSettings->maxDiscoverAttempts = $maxDiscoverAttempts;
@@ -97,7 +120,7 @@ class ClusterSettings
         return $this->externalGossipPort;
     }
 
-    public function gossipSeeds(): ?array
+    public function gossipSeeds(): array
     {
         return $this->gossipSeeds;
     }

--- a/src/ConnectionSettings.php
+++ b/src/ConnectionSettings.php
@@ -83,7 +83,7 @@ class ConnectionSettings
     /** @internal */
     public function __construct(
         Log $logger,
-        bool $verboseLoggin,
+        bool $verboseLogging,
         int $maxQueueSize,
         int $maxConcurrentItems,
         int $maxRetries,
@@ -108,11 +108,11 @@ class ConnectionSettings
         int $clientConnectionTimeout
     ) {
         if ($heartbeatInterval >= 5000) {
-            throw new InvalidArgumentException('Heartbeat interval must be less then 5000ms');
+            throw new InvalidArgumentException('Heartbeat interval must be less than 5000ms');
         }
 
         $this->log = $logger;
-        $this->verboseLogging = $verboseLoggin;
+        $this->verboseLogging = $verboseLogging;
         $this->maxQueueSize = $maxQueueSize;
         $this->maxConcurrentItems = $maxConcurrentItems;
         $this->maxRetries = $maxRetries;

--- a/src/ConnectionString.php
+++ b/src/ConnectionString.php
@@ -51,10 +51,10 @@ class ConnectionString
         $settings = $settings ?? ConnectionSettings::default();
         $reflection = new ReflectionObject($settings);
         $properties = $reflection->getProperties();
-        $values = \explode(';', $connectionString);
+        $values = self::getParts($connectionString);
 
         foreach ($values as $value) {
-            list($key, $value) = \explode('=', $value);
+            [$key, $value] = \explode('=', $value);
             $key = \strtolower($key);
 
             if ('connectto' === $key) {
@@ -152,10 +152,10 @@ class ConnectionString
 
     public static function getUriFromConnectionString(string $connectionString): ?Uri
     {
-        $values = \explode(';', $connectionString);
+        $values = self::getParts($connectionString);
 
         foreach ($values as $value) {
-            list($key, $value) = \explode('=', $value);
+            [$key, $value] = \explode('=', $value);
 
             if (\strtolower($key) === 'connectto') {
                 return Uri::fromString($value);
@@ -164,4 +164,14 @@ class ConnectionString
 
         return null;
     }
+
+    /**
+     * @param string $connectionString
+     *
+     * @return string[]
+     */
+    private static function getParts(string $connectionString): array
+    {
+        return array_map('\trim', \explode(';', $connectionString));
+}
 }

--- a/src/ConnectionString.php
+++ b/src/ConnectionString.php
@@ -172,6 +172,6 @@ class ConnectionString
      */
     private static function getParts(string $connectionString): array
     {
-        return array_map('\trim', \explode(';', $connectionString));
-}
+        return \array_map('\trim', \explode(';', $connectionString));
+    }
 }

--- a/src/Internal/ClusterDnsEndPointDiscoverer.php
+++ b/src/Internal/ClusterDnsEndPointDiscoverer.php
@@ -131,7 +131,10 @@ final class ClusterDnsEndPointDiscoverer implements EndPointDiscoverer
         });
     }
 
-    /** @return Promise<NodeEndPoints|null> */
+    /**
+     * @param null|EndPoint $failedTcpEndPoint
+     * @return Promise<NodeEndPoints|null>
+     */
     private function discoverEndPoint(?EndPoint $failedTcpEndPoint): Promise
     {
         return call(function () use ($failedTcpEndPoint): Generator {
@@ -226,7 +229,10 @@ final class ClusterDnsEndPointDiscoverer implements EndPointDiscoverer
         return $result;
     }
 
-    /** @return Promise<ClusterInfoDto|null> */
+    /**
+     * @param GossipSeed $endPoint
+     * @return Promise<ClusterInfoDto|null>
+     */
     private function tryGetGossipFrom(GossipSeed $endPoint): Promise
     {
         return call(function () use ($endPoint): Generator {

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -69,7 +69,7 @@ class Uri
 
         if (isset($parts['user'])) {
             $user = self::filterUserInfoPart($parts['user']);
-            $pass = $pass['pass'] ?? '';
+            $pass = $parts['pass'] ?? '';
 
             $userCredentials = new UserCredentials($user, $pass);
         }

--- a/tests/EventStoreAsyncConnectionFactoryTest.php
+++ b/tests/EventStoreAsyncConnectionFactoryTest.php
@@ -1,14 +1,23 @@
 <?php
 
+/**
+ * This file is part of `prooph/event-store-client`.
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace ProophTest\EventStoreClient;
 
+use PHPUnit\Framework\TestCase;
 use Prooph\EventStoreClient\ClusterSettings;
 use Prooph\EventStoreClient\ConnectionSettings;
 use Prooph\EventStoreClient\EndPoint;
 use Prooph\EventStoreClient\EventStoreAsyncConnectionFactory as Factory;
-use PHPUnit\Framework\TestCase;
 use Prooph\EventStoreClient\Exception\InvalidArgumentException;
 use Prooph\EventStoreClient\GossipSeed;
 use Prooph\EventStoreClient\Uri;
@@ -118,8 +127,7 @@ final class EventStoreAsyncConnectionFactoryTest extends TestCase
             ->setMaxDiscoverAttempts(self::MAX_DISCOVER_ATTEMPTS)
             ->setGossipTimeout(self::CONNECT_TIMEOUT)
             ->preferRandomNode()
-            ->build()
-        ;
+            ->build();
 
         $clusterSettings = ClusterSettings::fromGossipSeeds(
             $this->getGossipSeeds(),
@@ -167,12 +175,10 @@ final class EventStoreAsyncConnectionFactoryTest extends TestCase
             ->setDefaultUserCredentials(
                 new UserCredentials('admin', 'changeit')
             )
-            ->build()
-        ;
+            ->build();
 
         $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
         $this->assertEquals($connectionSettings, $conn->connectionSettings());
-
     }
 
     /**
@@ -193,8 +199,7 @@ final class EventStoreAsyncConnectionFactoryTest extends TestCase
                 new GossipSeed(new EndPoint('192.168.0.2', 1111)),
                 new GossipSeed(new EndPoint('192.168.0.3', 1111)),
             ])
-            ->build()
-        ;
+            ->build();
 
         $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
         $this->assertEquals($connectionSettings, $conn->connectionSettings());
@@ -250,6 +255,7 @@ final class EventStoreAsyncConnectionFactoryTest extends TestCase
         $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
         $this->assertSame($connectionSettings, $conn->connectionSettings());
     }
+
     /**
      * @test
      */
@@ -284,8 +290,7 @@ final class EventStoreAsyncConnectionFactoryTest extends TestCase
             ->setGossipSeeds(
                 $this->getGossipSeeds()
             )
-            ->build()
-        ;
+            ->build();
 
         $conn = Factory::createFromSettings(
             $connectionSettings,
@@ -319,8 +324,7 @@ final class EventStoreAsyncConnectionFactoryTest extends TestCase
             ->setDefaultUserCredentials(
                 new UserCredentials('admin', 'changeit')
             )
-            ->build()
-        ;
+            ->build();
 
         $conn = Factory::createFromEndPoint(
             $this->getEndpoint(),
@@ -331,7 +335,6 @@ final class EventStoreAsyncConnectionFactoryTest extends TestCase
         $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
         $this->assertSame($connectionSettings, $conn->connectionSettings());
     }
-
 
     /**
      * @test
@@ -354,7 +357,7 @@ final class EventStoreAsyncConnectionFactoryTest extends TestCase
     private function getGossipSeeds(): array
     {
         return [
-            new GossipSeed($this->getEndpoint())
+            new GossipSeed($this->getEndpoint()),
         ];
     }
 

--- a/tests/EventStoreAsyncConnectionFactoryTest.php
+++ b/tests/EventStoreAsyncConnectionFactoryTest.php
@@ -1,0 +1,368 @@
+<?php
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStoreClient;
+
+use Prooph\EventStoreClient\ClusterSettings;
+use Prooph\EventStoreClient\ConnectionSettings;
+use Prooph\EventStoreClient\EndPoint;
+use Prooph\EventStoreClient\EventStoreAsyncConnectionFactory as Factory;
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStoreClient\Exception\InvalidArgumentException;
+use Prooph\EventStoreClient\GossipSeed;
+use Prooph\EventStoreClient\Uri;
+use Prooph\EventStoreClient\UserCredentials;
+
+final class EventStoreAsyncConnectionFactoryTest extends TestCase
+{
+    private const CONNECTION_NAME = 'test-conn';
+    private const CLUSTER_DNS = 'escluster.net';
+    private const CONNECT_TIMEOUT = 1000;
+    private const MAX_DISCOVER_ATTEMPTS = 3;
+    private const EXTERNAL_GOSSIP_PORT = 2112;
+
+    /**
+     * @test
+     */
+    public function create_from_uri_with_discover_scheme(): void
+    {
+        $conn = Factory::createFromUri(
+            Uri::fromString('discover://eventstore:2113'),
+            null,
+            self::CONNECTION_NAME
+        );
+
+        $connectionSettings = ConnectionSettings::default();
+        $clusterSettings = ClusterSettings::fromClusterDns(
+            'eventstore',
+            10,
+            2113,
+            self::CONNECT_TIMEOUT,
+            false
+        );
+
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertEquals($clusterSettings, $conn->clusterSettings());
+        $this->assertEquals($connectionSettings, $conn->connectionSettings());
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_uri_with_discover_scheme_defaults_to_uri_credentials(): void
+    {
+        $conn = Factory::createFromUri(
+            Uri::fromString('discover://us3r:p$ss@eventstore:2113')
+        );
+
+        $this->assertEquals(
+            new UserCredentials('us3r', 'p$ss'),
+            $conn->connectionSettings()->defaultUserCredentials()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_uri_with_tcp_scheme(): void
+    {
+        $conn = Factory::createFromUri(
+            Uri::fromString('tcp://eventstore:1113'),
+            null,
+            self::CONNECTION_NAME
+        );
+
+        $connectionSettings = ConnectionSettings::default();
+
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertEquals($connectionSettings, $conn->connectionSettings());
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_uri_with_tcp_scheme_defaults_to_uri_credentials(): void
+    {
+        $conn = Factory::createFromUri(
+            Uri::fromString('tcp://us3r:p$ss@eventstore:1113')
+        );
+
+        $this->assertEquals(
+            new UserCredentials('us3r', 'p$ss'),
+            $conn->connectionSettings()->defaultUserCredentials()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_uri_with_unknown_scheme_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Unknown scheme for connection');
+
+        Factory::createFromUri(
+            Uri::fromString('unknown://eventstore:1113')
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_uri_with_gossip_seeds(): void
+    {
+        $connectionSettings = ConnectionSettings
+            ::create()
+            ->setGossipSeeds($this->getGossipSeeds())
+            ->setMaxDiscoverAttempts(self::MAX_DISCOVER_ATTEMPTS)
+            ->setGossipTimeout(self::CONNECT_TIMEOUT)
+            ->preferRandomNode()
+            ->build()
+        ;
+
+        $clusterSettings = ClusterSettings::fromGossipSeeds(
+            $this->getGossipSeeds(),
+            self::MAX_DISCOVER_ATTEMPTS,
+            self::CONNECT_TIMEOUT,
+            true
+        );
+
+        $conn = Factory::createFromUri(
+            null,
+            $connectionSettings,
+            self::CONNECTION_NAME
+        );
+
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertSame($connectionSettings, $conn->connectionSettings());
+        $this->assertEquals($clusterSettings, $conn->clusterSettings());
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_uri_without_arguments_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Must specify uri or gossip seeds');
+
+        Factory::createFromUri(null);
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_connection_string(): void
+    {
+        $conn = Factory::createFromConnectionString(
+            'ConnectTo=tcp://admin:changeit@eventstore:1113; HeartBeatTimeout=500',
+            null,
+            self::CONNECTION_NAME
+        );
+
+        $connectionSettings = ConnectionSettings
+            ::create()
+            ->setHeartbeatTimeout(500)
+            ->setDefaultUserCredentials(
+                new UserCredentials('admin', 'changeit')
+            )
+            ->build()
+        ;
+
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertEquals($connectionSettings, $conn->connectionSettings());
+
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_connection_string_with_gossip_seeds(): void
+    {
+        $conn = Factory::createFromConnectionString(
+            'GossipSeeds=192.168.0.2:1111,192.168.0.3:1111; HeartBeatTimeout=500',
+            null,
+            self::CONNECTION_NAME
+        );
+
+        $connectionSettings = ConnectionSettings
+            ::create()
+            ->setHeartbeatTimeout(500)
+            ->setGossipSeeds([
+                new GossipSeed(new EndPoint('192.168.0.2', 1111)),
+                new GossipSeed(new EndPoint('192.168.0.3', 1111)),
+            ])
+            ->build()
+        ;
+
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertEquals($connectionSettings, $conn->connectionSettings());
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_connection_string_requires_connectto_or_gossip_seeds(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Did not find ConnectTo or GossipSeeds in the connection string');
+
+        Factory::createFromConnectionString(
+            'ClusterDns=escluster.net; HeartBeatTimeout=500'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_connection_string_requires_only_one_of_connectto_and_gossip_seeds(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Setting ConnectTo as well as GossipSeeds on the connection string is currently not supported');
+
+        Factory::createFromConnectionString(
+            'ConnectTo=tcp://eventstore:1113; GossipSeeds=192.168.0.2:1111,192.168.0.3:1111'
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_cluster_settings_with_dns(): void
+    {
+        $connectionSettings = ConnectionSettings::default();
+        $clusterSettings = ClusterSettings::fromClusterDns(
+            self::CLUSTER_DNS,
+            self::MAX_DISCOVER_ATTEMPTS,
+            self::EXTERNAL_GOSSIP_PORT,
+            self::CONNECT_TIMEOUT,
+            true
+        );
+
+        $conn = Factory::createFromClusterSettings(
+            $connectionSettings,
+            $clusterSettings,
+            self::CONNECTION_NAME
+        );
+
+        $this->assertSame($clusterSettings, $conn->clusterSettings());
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertSame($connectionSettings, $conn->connectionSettings());
+    }
+    /**
+     * @test
+     */
+    public function create_from_cluster_settings_with_gossip_seeds(): void
+    {
+        $connectionSettings = ConnectionSettings::default();
+        $clusterSettings = ClusterSettings::fromGossipSeeds(
+            $this->getGossipSeeds(),
+            self::MAX_DISCOVER_ATTEMPTS,
+            self::CONNECT_TIMEOUT,
+            true
+        );
+
+        $conn = Factory::createFromClusterSettings(
+            $connectionSettings,
+            $clusterSettings,
+            self::CONNECTION_NAME
+        );
+
+        $this->assertSame($clusterSettings, $conn->clusterSettings());
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertSame($connectionSettings, $conn->connectionSettings());
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_settings_with_gossip_seeds(): void
+    {
+        $connectionSettings = ConnectionSettings
+            ::create()
+            ->setGossipSeeds(
+                $this->getGossipSeeds()
+            )
+            ->build()
+        ;
+
+        $conn = Factory::createFromSettings(
+            $connectionSettings,
+            self::CONNECTION_NAME
+        );
+
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertSame($connectionSettings, $conn->connectionSettings());
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_settings_without_gossip_seeds_throws(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+
+        Factory::createFromSettings(
+            ConnectionSettings::default()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function create_from_endpoint(): void
+    {
+        $connectionSettings = ConnectionSettings
+            ::create()
+            ->performOnAnyNode()
+            ->setDefaultUserCredentials(
+                new UserCredentials('admin', 'changeit')
+            )
+            ->build()
+        ;
+
+        $conn = Factory::createFromEndPoint(
+            $this->getEndpoint(),
+            $connectionSettings,
+            self::CONNECTION_NAME
+        );
+
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertSame($connectionSettings, $conn->connectionSettings());
+    }
+
+
+    /**
+     * @test
+     */
+    public function create_from_endpoint_uses_default_settings(): void
+    {
+        $conn = Factory::createFromEndPoint(
+            $this->getEndpoint(),
+            null,
+            self::CONNECTION_NAME
+        );
+
+        $this->assertSame(self::CONNECTION_NAME, $conn->connectionName());
+        $this->assertEquals(ConnectionSettings::default(), $conn->connectionSettings());
+    }
+
+    /**
+     * @return array
+     */
+    private function getGossipSeeds(): array
+    {
+        return [
+            new GossipSeed($this->getEndpoint())
+        ];
+    }
+
+    /**
+     * @return EndPoint
+     */
+    private function getEndpoint(): EndPoint
+    {
+        return new EndPoint('127.0.0.1', 1113);
+    }
+}


### PR DESCRIPTION
The `ClusterSettings`, `ConnectionSettings`, and `ConnectionString` classes had some bugs in them, and were somewhat untested.

I've added a test for the connection factory, covering most cases I could think of, and find in the code/documentation.

I also added a new example to demo consuming from a subscription within a cluster, which works when you start the DNS cluster in Docker, and run the PHP script locally. This is because the DNS cluster advertises as 127.0.0.1, which does not resolve to the event store in the PHP container, if you run it in Docker.

```
❯ php examples/demo-subscription-with-cluster.php
connected
connected
no such subscription exists (yet)
object(Prooph\EventStoreClient\Internal\PersistentSubscriptionCreateResult)#234 (1) {
  ["status":"Prooph\EventStoreClient\Internal\PersistentSubscriptionCreateResult":private]=>
  object(Prooph\EventStoreClient\Internal\PersistentSubscriptionCreateStatus)#112 (2) {
    ["name":"Prooph\EventStoreClient\Internal\PersistentSubscriptionCreateStatus":private]=>
    string(7) "Success"
    ["value":"Prooph\EventStoreClient\Internal\PersistentSubscriptionCreateStatus":private]=>
    int(0)
  }
}
dropped with reason: UserInitiated
connection closed
```