### PR TITLE
Remove type=JS from ProjectionsClient::updateQuery()

### DIFF
--- a/src/Projections/ProjectionsClient.php
+++ b/src/Projections/ProjectionsClient.php
@@ -468,7 +468,7 @@ class ProjectionsClient
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
                 $httpSchema,
-                '/projection/%s/query?emit=' . (int) $emitEnabled . '&type=JS',
+                '/projection/%s/query?emit=' . (int) $emitEnabled,
                 $name
             ),
             $query,


### PR DESCRIPTION
Closes #56

I think this is the easiest fix. When updating a query we don't need to specify the projection type.