### PR TITLE
Fix required version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "amphp/byte-stream": "^1.5.1",
     "amphp/file": "^0.3.3",
     "amphp/socket": "^0.10.11",
-    "prooph/event-store": "dev-master",
+    "prooph/event-store": "^8.0.0@beta",
     "ramsey/uuid": "^3.8"
   },
   "require-dev": {


### PR DESCRIPTION
Fix for https://github.com/prooph/event-store-client/issues/82. Of course a new release is necessary.