### PR TITLE
Provide verify peer option

### DIFF
--- a/src/PersistentSubscriptions/PersistentSubscriptionsClient.php
+++ b/src/PersistentSubscriptions/PersistentSubscriptionsClient.php
@@ -32,13 +32,11 @@ use UnexpectedValueException;
 class PersistentSubscriptionsClient
 {
     private HttpClient $client;
-    private int $operationTimeout;
     private string $httpSchema;
 
-    public function __construct(int $operationTimeout, bool $tlsTerminatedEndpoint)
+    public function __construct(int $operationTimeout, bool $tlsTerminatedEndpoint, bool $verifyPeer)
     {
-        $this->client = new HttpClient($operationTimeout);
-        $this->operationTimeout = $operationTimeout;
+        $this->client = new HttpClient($operationTimeout, $verifyPeer);
         $this->httpSchema = $tlsTerminatedEndpoint ? EndpointExtensions::HTTPS_SCHEMA : EndpointExtensions::HTTP_SCHEMA;
     }
 

--- a/src/PersistentSubscriptions/PersistentSubscriptionsManager.php
+++ b/src/PersistentSubscriptions/PersistentSubscriptionsManager.php
@@ -30,9 +30,10 @@ class PersistentSubscriptionsManager implements AsyncPersistentSubscriptionsMana
         EndPoint $httpEndPoint,
         int $operationTimeout,
         bool $tlsTerminatedEndpoint = false,
+        bool $verifyPeer = true,
         ?UserCredentials $defaultUserCredentials = null
     ) {
-        $this->client = new PersistentSubscriptionsClient($operationTimeout, $tlsTerminatedEndpoint);
+        $this->client = new PersistentSubscriptionsClient($operationTimeout, $tlsTerminatedEndpoint, $verifyPeer);
         $this->httpEndPoint = $httpEndPoint;
         $this->defaultUserCredentials = $defaultUserCredentials;
     }

--- a/src/Projections/ProjectionsClient.php
+++ b/src/Projections/ProjectionsClient.php
@@ -39,9 +39,9 @@ class ProjectionsClient
     private int $operationTimeout;
     private string $httpSchema;
 
-    public function __construct(int $operationTimeout, bool $tlsTerminatedEndpoint)
+    public function __construct(int $operationTimeout, bool $tlsTerminatedEndpoint, bool $verifyPeer)
     {
-        $this->client = new HttpClient($operationTimeout);
+        $this->client = new HttpClient($operationTimeout, $verifyPeer);
         $this->operationTimeout = $operationTimeout;
         $this->httpSchema = $tlsTerminatedEndpoint ? EndpointExtensions::HTTPS_SCHEMA : EndpointExtensions::HTTP_SCHEMA;
     }

--- a/src/Projections/ProjectionsManager.php
+++ b/src/Projections/ProjectionsManager.php
@@ -29,9 +29,10 @@ class ProjectionsManager implements AsyncProjectionsManager
         EndPoint $httpEndPoint,
         int $operationTimeout,
         bool $tlsTerminatedEndpoint = false,
+        bool $verifyPeer = true,
         ?UserCredentials $defaultUserCredentials = null
     ) {
-        $this->client = new ProjectionsClient($operationTimeout, $tlsTerminatedEndpoint);
+        $this->client = new ProjectionsClient($operationTimeout, $tlsTerminatedEndpoint, $verifyPeer);
         $this->httpEndPoint = $httpEndPoint;
         $this->defaultUserCredentials = $defaultUserCredentials;
     }

--- a/src/Projections/QueryManager.php
+++ b/src/Projections/QueryManager.php
@@ -37,13 +37,15 @@ class QueryManager implements AsyncQueryManager
         int $projectionOperationTimeout,
         int $queryTimeout,
         bool $tlsTerminatedEndpoint = false,
+        bool $verifyPeer = true,
         ?UserCredentials $defaultUserCredentials = null
     ) {
         $this->queryTimeout = $queryTimeout;
         $this->projectionsManager = new ProjectionsManager(
             $httpEndPoint,
             $projectionOperationTimeout,
-            $tlsTerminatedEndpoint
+            $tlsTerminatedEndpoint,
+            $verifyPeer,
         );
         $this->defaultUserCredentials = $defaultUserCredentials;
     }

--- a/src/UserManagement/UsersClient.php
+++ b/src/UserManagement/UsersClient.php
@@ -40,9 +40,9 @@ class UsersClient
     private int $operationTimeout;
     private string $httpSchema;
 
-    public function __construct(int $operationTimeout, bool $tlsTerminatedEndpoint)
+    public function __construct(int $operationTimeout, bool $tlsTerminatedEndpoint, bool $verifyPeer)
     {
-        $this->client = new HttpClient($operationTimeout);
+        $this->client = new HttpClient($operationTimeout, $verifyPeer);
         $this->operationTimeout = $operationTimeout;
         $this->httpSchema = $tlsTerminatedEndpoint ? EndpointExtensions::HTTPS_SCHEMA : EndpointExtensions::HTTP_SCHEMA;
     }

--- a/src/UserManagement/UsersManager.php
+++ b/src/UserManagement/UsersManager.php
@@ -33,9 +33,10 @@ class UsersManager implements AsyncUsersManager
         EndPoint $endPoint,
         int $operationTimeout,
         bool $tlsTerminatedEndpoint = false,
+        bool $verifyPeer = true,
         ?UserCredentials $userCredentials = null
     ) {
-        $this->client = new UsersClient($operationTimeout, $tlsTerminatedEndpoint);
+        $this->client = new UsersClient($operationTimeout, $tlsTerminatedEndpoint, $verifyPeer);
         $this->endPoint = $endPoint;
         $this->defaultCredentials = $userCredentials;
     }

--- a/tests/PersistentSubscriptionManagement/persistent_subscription_manager.php
+++ b/tests/PersistentSubscriptionManagement/persistent_subscription_manager.php
@@ -53,6 +53,7 @@ class persistent_subscription_manager extends AsyncTestCase
             ),
             5000,
             false,
+            false,
             DefaultData::adminCredentials()
         );
         $this->stream = Guid::generateAsHex();

--- a/tests/Security/AuthenticationTestCase.php
+++ b/tests/Security/AuthenticationTestCase.php
@@ -45,6 +45,7 @@ abstract class AuthenticationTestCase extends AsyncTestCase
             TestConnection::httpEndPoint(),
             5000,
             false,
+            false,
             $this->adminUser()
         );
 
@@ -165,6 +166,7 @@ abstract class AuthenticationTestCase extends AsyncTestCase
         $manager = new UsersManager(
             TestConnection::httpEndPoint(),
             5000,
+            false,
             false,
             $this->adminUser()
         );

--- a/tests/UserManagement/list_users.php
+++ b/tests/UserManagement/list_users.php
@@ -64,6 +64,7 @@ class list_users extends TestWithNode
             ),
             5000,
             false,
+            false,
             DefaultData::adminCredentials()
         );
 


### PR DESCRIPTION
According to [Event Store 6 Release Notes](https://eventstore.com/blog/event-store-6.0.0-preview-release/):
> With the preview release of Event Store, Event Store will only expose the external HTTP interface over HTTPS.
>
> This requires a TLS certificate, but for ease of use we have introduced a development mode which uses a self signed certificate intended for development use only. Development mode can be enabled by specifying the --dev option when starting Event Store

There is a need to disable peer verification.