### PR TITLE
Fix subscription dropped

### DIFF
--- a/src/Internal/EventStoreConnectionLogicHandler.php
+++ b/src/Internal/EventStoreConnectionLogicHandler.php
@@ -657,7 +657,10 @@ class EventStoreConnectionLogicHandler
                     $message->userCredentials(),
                     fn (EventStoreSubscription $subscription, ResolvedEvent $resolvedEvent): Promise => ($message->eventAppeared())($subscription, $resolvedEvent),
                     function (EventStoreSubscription $subscription, SubscriptionDropReason $reason, ?Throwable $exception = null) use ($message): void {
-                        ($message->subscriptionDropped())($subscription, $reason, $exception);
+                        $subscriptionDroppedHandler = $message->subscriptionDropped();
+                        if ($subscriptionDroppedHandler !== null) {
+                            $subscriptionDroppedHandler($subscription, $reason, $exception);
+                        }
                     },
                     $this->settings->verboseLogging(),
                     fn (): ?TcpPackageConnection => $this->connection


### PR DESCRIPTION
Just notice this potential bug while reading the code. I didn't actually encounter it.

`StartSubscriptionMessage::subscriptionDropped()` can return null in which case this would cause an error.

WIP because we should add a test for this.
