### PR TITLE
Add psr log to the dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,8 @@
     "amphp/file": "^1.0.0",
     "amphp/socket": "^1.0.0",
     "google/protobuf": "^3.9",
-    "prooph/event-store": "dev-master"
+    "prooph/event-store": "dev-master",
+    "psr/log": "^1.1.0"
   },
   "require-dev": {
     "amphp/log": "^1.0",


### PR DESCRIPTION
Problem: if you do not have psr/log installed as side of
this library, it will fail.

Solution: add it as dependency.