### PR TITLE
Change constructors for http communications

### DIFF
--- a/src/PersistentSubscriptions/PersistentSubscriptionsClient.php
+++ b/src/PersistentSubscriptions/PersistentSubscriptionsClient.php
@@ -33,11 +33,13 @@ class PersistentSubscriptionsClient
 {
     private HttpClient $client;
     private int $operationTimeout;
+    private string $httpSchema;
 
-    public function __construct(int $operationTimeout)
+    public function __construct(int $operationTimeout, bool $tlsTerminatedEndpoint)
     {
         $this->client = new HttpClient($operationTimeout);
         $this->operationTimeout = $operationTimeout;
+        $this->httpSchema = $tlsTerminatedEndpoint ? EndpointExtensions::HTTPS_SCHEMA : EndpointExtensions::HTTP_SCHEMA;
     }
 
     /**
@@ -47,15 +49,14 @@ class PersistentSubscriptionsClient
         EndPoint $endPoint,
         string $stream,
         string $subscriptionName,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         $deferred = new Deferred();
 
         $promise = $this->sendGet(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/subscriptions/%s/%s/info',
                 $stream,
                 $subscriptionName
@@ -97,8 +98,7 @@ class PersistentSubscriptionsClient
     public function list(
         EndPoint $endPoint,
         ?string $stream = null,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         $deferred = new Deferred();
 
@@ -111,7 +111,7 @@ class PersistentSubscriptionsClient
         $promise = $this->sendGet(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 $formatString
             ),
             $userCredentials,
@@ -156,13 +156,12 @@ class PersistentSubscriptionsClient
         EndPoint $endPoint,
         string $stream,
         string $subscriptionName,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         return $this->sendPost(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/subscriptions/%s/%s/replayParked',
                 $stream,
                 $subscriptionName

--- a/src/PersistentSubscriptions/PersistentSubscriptionsManager.php
+++ b/src/PersistentSubscriptions/PersistentSubscriptionsManager.php
@@ -18,25 +18,22 @@ use Prooph\EventStore\Async\PersistentSubscriptions\PersistentSubscriptionsManag
 use Prooph\EventStore\EndPoint;
 use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStore\PersistentSubscriptions\PersistentSubscriptionDetails;
-use Prooph\EventStore\Transport\Http\EndpointExtensions;
 use Prooph\EventStore\UserCredentials;
 
 class PersistentSubscriptionsManager implements AsyncPersistentSubscriptionsManager
 {
     private PersistentSubscriptionsClient $client;
     private EndPoint $httpEndPoint;
-    private string $httpSchema;
     private ?UserCredentials $defaultUserCredentials;
 
     public function __construct(
         EndPoint $httpEndPoint,
         int $operationTimeout,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA,
+        bool $tlsTerminatedEndpoint = false,
         ?UserCredentials $defaultUserCredentials = null
     ) {
-        $this->client = new PersistentSubscriptionsClient($operationTimeout);
+        $this->client = new PersistentSubscriptionsClient($operationTimeout, $tlsTerminatedEndpoint);
         $this->httpEndPoint = $httpEndPoint;
-        $this->httpSchema = $httpSchema;
         $this->defaultUserCredentials = $defaultUserCredentials;
     }
 
@@ -60,8 +57,7 @@ class PersistentSubscriptionsManager implements AsyncPersistentSubscriptionsMana
             $this->httpEndPoint,
             $stream,
             $subscriptionName,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -83,8 +79,7 @@ class PersistentSubscriptionsManager implements AsyncPersistentSubscriptionsMana
             $this->httpEndPoint,
             $stream,
             $subscriptionName,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -100,8 +95,7 @@ class PersistentSubscriptionsManager implements AsyncPersistentSubscriptionsMana
         return $this->client->list(
             $this->httpEndPoint,
             $stream,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 }

--- a/src/Projections/ProjectionsManager.php
+++ b/src/Projections/ProjectionsManager.php
@@ -17,25 +17,22 @@ use Amp\Promise;
 use Prooph\EventStore\Async\Projections\ProjectionsManager as AsyncProjectionsManager;
 use Prooph\EventStore\EndPoint;
 use Prooph\EventStore\Exception\InvalidArgumentException;
-use Prooph\EventStore\Transport\Http\EndpointExtensions;
 use Prooph\EventStore\UserCredentials;
 
 class ProjectionsManager implements AsyncProjectionsManager
 {
     private ProjectionsClient $client;
     private EndPoint $httpEndPoint;
-    private string $httpSchema;
     private ?UserCredentials $defaultUserCredentials;
 
     public function __construct(
         EndPoint $httpEndPoint,
         int $operationTimeout,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA,
+        bool $tlsTerminatedEndpoint = false,
         ?UserCredentials $defaultUserCredentials = null
     ) {
-        $this->client = new ProjectionsClient($operationTimeout);
+        $this->client = new ProjectionsClient($operationTimeout, $tlsTerminatedEndpoint);
         $this->httpEndPoint = $httpEndPoint;
-        $this->httpSchema = $httpSchema;
         $this->defaultUserCredentials = $defaultUserCredentials;
     }
 
@@ -49,8 +46,7 @@ class ProjectionsManager implements AsyncProjectionsManager
         return $this->client->enable(
             $this->httpEndPoint,
             $name,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -64,8 +60,7 @@ class ProjectionsManager implements AsyncProjectionsManager
         return $this->client->disable(
             $this->httpEndPoint,
             $name,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -79,8 +74,7 @@ class ProjectionsManager implements AsyncProjectionsManager
         return $this->client->abort(
             $this->httpEndPoint,
             $name,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -98,8 +92,7 @@ class ProjectionsManager implements AsyncProjectionsManager
             $this->httpEndPoint,
             $query,
             $type,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -123,8 +116,7 @@ class ProjectionsManager implements AsyncProjectionsManager
             $name,
             $query,
             $type,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -150,8 +142,7 @@ class ProjectionsManager implements AsyncProjectionsManager
             $query,
             $trackEmittedStreams,
             $type,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -160,8 +151,7 @@ class ProjectionsManager implements AsyncProjectionsManager
     {
         return $this->client->listAll(
             $this->httpEndPoint,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -170,8 +160,7 @@ class ProjectionsManager implements AsyncProjectionsManager
     {
         return $this->client->listOneTime(
             $this->httpEndPoint,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -180,8 +169,7 @@ class ProjectionsManager implements AsyncProjectionsManager
     {
         return $this->client->listContinuous(
             $this->httpEndPoint,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -195,8 +183,7 @@ class ProjectionsManager implements AsyncProjectionsManager
         return $this->client->getStatus(
             $this->httpEndPoint,
             $name,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -210,8 +197,7 @@ class ProjectionsManager implements AsyncProjectionsManager
         return $this->client->getState(
             $this->httpEndPoint,
             $name,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -233,8 +219,7 @@ class ProjectionsManager implements AsyncProjectionsManager
             $this->httpEndPoint,
             $name,
             $partition,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -248,8 +233,7 @@ class ProjectionsManager implements AsyncProjectionsManager
         return $this->client->getResult(
             $this->httpEndPoint,
             $name,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -271,8 +255,7 @@ class ProjectionsManager implements AsyncProjectionsManager
             $this->httpEndPoint,
             $name,
             $partition,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -286,8 +269,7 @@ class ProjectionsManager implements AsyncProjectionsManager
         return $this->client->getStatistics(
             $this->httpEndPoint,
             $name,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -301,8 +283,7 @@ class ProjectionsManager implements AsyncProjectionsManager
         return $this->client->getQuery(
             $this->httpEndPoint,
             $name,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -326,8 +307,7 @@ class ProjectionsManager implements AsyncProjectionsManager
             $name,
             $query,
             $emitEnabled,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -345,8 +325,7 @@ class ProjectionsManager implements AsyncProjectionsManager
             $this->httpEndPoint,
             $name,
             $deleteEmittedStreams,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 
@@ -360,8 +339,7 @@ class ProjectionsManager implements AsyncProjectionsManager
         return $this->client->reset(
             $this->httpEndPoint,
             $name,
-            $userCredentials ?? $this->defaultUserCredentials,
-            $this->httpSchema
+            $userCredentials ?? $this->defaultUserCredentials
         );
     }
 }

--- a/src/Projections/QueryManager.php
+++ b/src/Projections/QueryManager.php
@@ -20,7 +20,6 @@ use Generator;
 use Prooph\EventStore\Async\Projections\QueryManager as AsyncQueryManager;
 use Prooph\EventStore\EndPoint;
 use Prooph\EventStore\Projections\ProjectionDetails;
-use Prooph\EventStore\Transport\Http\EndpointExtensions;
 use Prooph\EventStore\UserCredentials;
 
 /**
@@ -37,14 +36,14 @@ class QueryManager implements AsyncQueryManager
         EndPoint $httpEndPoint,
         int $projectionOperationTimeout,
         int $queryTimeout,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA,
+        bool $tlsTerminatedEndpoint = false,
         ?UserCredentials $defaultUserCredentials = null
     ) {
         $this->queryTimeout = $queryTimeout;
         $this->projectionsManager = new ProjectionsManager(
             $httpEndPoint,
             $projectionOperationTimeout,
-            $httpSchema
+            $tlsTerminatedEndpoint
         );
         $this->defaultUserCredentials = $defaultUserCredentials;
     }

--- a/src/UserManagement/UsersClient.php
+++ b/src/UserManagement/UsersClient.php
@@ -38,24 +38,25 @@ class UsersClient
 {
     private HttpClient $client;
     private int $operationTimeout;
+    private string $httpSchema;
 
-    public function __construct(int $operationTimeout)
+    public function __construct(int $operationTimeout, bool $tlsTerminatedEndpoint)
     {
         $this->client = new HttpClient($operationTimeout);
         $this->operationTimeout = $operationTimeout;
+        $this->httpSchema = $tlsTerminatedEndpoint ? EndpointExtensions::HTTPS_SCHEMA : EndpointExtensions::HTTP_SCHEMA;
     }
 
     /** @return Promise<void> */
     public function enable(
         EndPoint $endPoint,
         string $login,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         return $this->sendPost(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/users/%s/command/enable',
                 \urlencode($login)
             ),
@@ -69,13 +70,12 @@ class UsersClient
     public function disable(
         EndPoint $endPoint,
         string $login,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         return $this->sendPost(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/users/%s/command/disable',
                 \urlencode($login)
             ),
@@ -89,13 +89,12 @@ class UsersClient
     public function delete(
         EndPoint $endPoint,
         string $login,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         return $this->sendDelete(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/users/%s',
                 \urlencode($login)
             ),
@@ -111,13 +110,12 @@ class UsersClient
      */
     public function listAll(
         EndPoint $endPoint,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         $deferred = new Deferred();
 
         $promise = $this->sendGet(
-            EndpointExtensions::rawUrlToHttpUrl($endPoint, $httpSchema, '/users/'),
+            EndpointExtensions::rawUrlToHttpUrl($endPoint, $this->httpSchema, '/users/'),
             $userCredentials,
             HttpStatusCode::OK
         );
@@ -160,15 +158,14 @@ class UsersClient
      */
     public function getCurrentUser(
         EndPoint $endPoint,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         $deferred = new Deferred();
 
         $promise = $this->sendGet(
             EndpointExtensions::rawUrlToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/users/$current'
             ),
             $userCredentials,
@@ -211,15 +208,14 @@ class UsersClient
     public function getUser(
         EndPoint $endPoint,
         string $login,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         $deferred = new Deferred();
 
         $promise = $this->sendGet(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/users/%s',
                 \urlencode($login)
             ),
@@ -259,13 +255,12 @@ class UsersClient
     public function createUser(
         EndPoint $endPoint,
         UserCreationInformation $newUser,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         return $this->sendPost(
             EndpointExtensions::rawUrlToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/users/'
             ),
             Json::encode($newUser),
@@ -279,13 +274,12 @@ class UsersClient
         EndPoint $endPoint,
         string $login,
         UserUpdateInformation $updatedUser,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         return $this->sendPut(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/users/%s',
                 \urlencode($login)
             ),
@@ -300,13 +294,12 @@ class UsersClient
         EndPoint $endPoint,
         string $login,
         ChangePasswordDetails $changePasswordDetails,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         return $this->sendPost(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/users/%s/command/change-password',
                 \urlencode($login)
             ),
@@ -321,13 +314,12 @@ class UsersClient
         EndPoint $endPoint,
         string $login,
         ResetPasswordDetails $resetPasswordDetails,
-        ?UserCredentials $userCredentials = null,
-        string $httpSchema = EndpointExtensions::HTTP_SCHEMA
+        ?UserCredentials $userCredentials = null
     ): Promise {
         return $this->sendPost(
             EndpointExtensions::formatStringToHttpUrl(
                 $endPoint,
-                $httpSchema,
+                $this->httpSchema,
                 '/users/%s/command/reset-password',
                 \urlencode($login)
             ),

--- a/src/UserManagement/UsersManager.php
+++ b/src/UserManagement/UsersManager.php
@@ -17,7 +17,6 @@ use Amp\Promise;
 use Prooph\EventStore\Async\UserManagement\UsersManager as AsyncUsersManager;
 use Prooph\EventStore\EndPoint;
 use Prooph\EventStore\Exception\InvalidArgumentException;
-use Prooph\EventStore\Transport\Http\EndpointExtensions;
 use Prooph\EventStore\UserCredentials;
 use Prooph\EventStore\UserManagement\ChangePasswordDetails;
 use Prooph\EventStore\UserManagement\ResetPasswordDetails;
@@ -28,18 +27,16 @@ class UsersManager implements AsyncUsersManager
 {
     private UsersClient $client;
     private EndPoint $endPoint;
-    private string $schema;
     private ?UserCredentials $defaultCredentials;
 
     public function __construct(
         EndPoint $endPoint,
         int $operationTimeout,
-        string $schema = EndpointExtensions::HTTP_SCHEMA,
+        bool $tlsTerminatedEndpoint = false,
         ?UserCredentials $userCredentials = null
     ) {
-        $this->client = new UsersClient($operationTimeout);
+        $this->client = new UsersClient($operationTimeout, $tlsTerminatedEndpoint);
         $this->endPoint = $endPoint;
-        $this->schema = $schema;
         $this->defaultCredentials = $userCredentials;
     }
 
@@ -53,8 +50,7 @@ class UsersManager implements AsyncUsersManager
         return $this->client->enable(
             $this->endPoint,
             $login,
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 
@@ -68,8 +64,7 @@ class UsersManager implements AsyncUsersManager
         return $this->client->disable(
             $this->endPoint,
             $login,
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 
@@ -83,8 +78,7 @@ class UsersManager implements AsyncUsersManager
         return $this->client->delete(
             $this->endPoint,
             $login,
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 
@@ -93,8 +87,7 @@ class UsersManager implements AsyncUsersManager
     {
         return $this->client->listAll(
             $this->endPoint,
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 
@@ -103,8 +96,7 @@ class UsersManager implements AsyncUsersManager
     {
         return $this->client->getCurrentUser(
             $this->endPoint,
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 
@@ -118,8 +110,7 @@ class UsersManager implements AsyncUsersManager
         return $this->client->getUser(
             $this->endPoint,
             $login,
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 
@@ -157,8 +148,7 @@ class UsersManager implements AsyncUsersManager
                 $groups,
                 $password
             ),
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 
@@ -187,8 +177,7 @@ class UsersManager implements AsyncUsersManager
             $this->endPoint,
             $login,
             new UserUpdateInformation($fullName, $groups),
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 
@@ -215,8 +204,7 @@ class UsersManager implements AsyncUsersManager
             $this->endPoint,
             $login,
             new ChangePasswordDetails($oldPassword, $newPassword),
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 
@@ -238,8 +226,7 @@ class UsersManager implements AsyncUsersManager
             $this->endPoint,
             $login,
             new ResetPasswordDetails($newPassword),
-            $userCredentials ?? $this->defaultCredentials,
-            $this->schema
+            $userCredentials ?? $this->defaultCredentials
         );
     }
 }

--- a/tests/PersistentSubscriptionManagement/persistent_subscription_manager.php
+++ b/tests/PersistentSubscriptionManagement/persistent_subscription_manager.php
@@ -27,7 +27,6 @@ use Prooph\EventStore\PersistentSubscriptionNakEventAction;
 use Prooph\EventStore\PersistentSubscriptions\PersistentSubscriptionDetails;
 use Prooph\EventStore\PersistentSubscriptionSettings;
 use Prooph\EventStore\ResolvedEvent;
-use Prooph\EventStore\Transport\Http\EndpointExtensions;
 use Prooph\EventStore\Util\Guid;
 use Prooph\EventStoreClient\PersistentSubscriptions\PersistentSubscriptionsManager;
 use ProophTest\EventStoreClient\CountdownEvent;
@@ -53,7 +52,7 @@ class persistent_subscription_manager extends AsyncTestCase
                 (int) \getenv('ES_HTTP_PORT')
             ),
             5000,
-            EndpointExtensions::HTTP_SCHEMA,
+            false,
             DefaultData::adminCredentials()
         );
         $this->stream = Guid::generateAsHex();
@@ -116,7 +115,7 @@ class persistent_subscription_manager extends AsyncTestCase
     {
         yield $this->execute(function (): Generator {
             $this->expectException(InvalidArgumentException::class);
-            yield $this->manager->describe('', 'existing');
+            $this->manager->describe('', 'existing');
         });
     }
 
@@ -125,7 +124,7 @@ class persistent_subscription_manager extends AsyncTestCase
     {
         yield $this->execute(function (): Generator {
             $this->expectException(InvalidArgumentException::class);
-            yield $this->manager->describe($this->stream, '');
+            $this->manager->describe($this->stream, '');
         });
     }
 
@@ -271,7 +270,7 @@ class persistent_subscription_manager extends AsyncTestCase
     {
         yield $this->execute(function (): Generator {
             $this->expectException(InvalidArgumentException::class);
-            yield $this->manager->replayParkedMessages('', 'existing');
+            $this->manager->replayParkedMessages('', 'existing');
         });
     }
 
@@ -280,7 +279,7 @@ class persistent_subscription_manager extends AsyncTestCase
     {
         yield $this->execute(function (): Generator {
             $this->expectException(InvalidArgumentException::class);
-            yield $this->manager->replayParkedMessages($this->stream, '');
+            $this->manager->replayParkedMessages($this->stream, '');
         });
     }
 }

--- a/tests/Security/AuthenticationTestCase.php
+++ b/tests/Security/AuthenticationTestCase.php
@@ -30,7 +30,6 @@ use Prooph\EventStore\Position;
 use Prooph\EventStore\ResolvedEvent;
 use Prooph\EventStore\StreamMetadata;
 use Prooph\EventStore\SystemSettings;
-use Prooph\EventStore\Transport\Http\EndpointExtensions;
 use Prooph\EventStore\UserCredentials;
 use Prooph\EventStoreClient\UserManagement\UsersManager;
 use ProophTest\EventStoreClient\Helper\TestConnection;
@@ -45,7 +44,7 @@ abstract class AuthenticationTestCase extends AsyncTestCase
         $manager = new UsersManager(
             TestConnection::httpEndPoint(),
             5000,
-            EndpointExtensions::HTTP_SCHEMA,
+            false,
             $this->adminUser()
         );
 
@@ -166,7 +165,7 @@ abstract class AuthenticationTestCase extends AsyncTestCase
         $manager = new UsersManager(
             TestConnection::httpEndPoint(),
             5000,
-            EndpointExtensions::HTTP_SCHEMA,
+            false,
             $this->adminUser()
         );
 

--- a/tests/UserManagement/list_users.php
+++ b/tests/UserManagement/list_users.php
@@ -15,7 +15,6 @@ namespace ProophTest\EventStoreClient\UserManagement;
 
 use Generator;
 use Prooph\EventStore\EndPoint;
-use Prooph\EventStore\Transport\Http\EndpointExtensions;
 use Prooph\EventStore\UserManagement\UserDetails;
 use Prooph\EventStoreClient\UserManagement\UsersManager;
 use ProophTest\EventStoreClient\DefaultData;
@@ -64,7 +63,7 @@ class list_users extends TestWithNode
                 (int) \getenv('ES_HTTP_PORT')
             ),
             5000,
-            EndpointExtensions::HTTP_SCHEMA,
+            false,
             DefaultData::adminCredentials()
         );
 

--- a/tests/read_all_events_backward_should.php
+++ b/tests/read_all_events_backward_should.php
@@ -184,7 +184,7 @@ class read_all_events_backward_should extends AsyncTestCase
         yield $this->execute(function (): Generator {
             $this->expectException(InvalidArgumentException::class);
 
-            yield $this->connection->readAllEventsBackwardAsync(Position::start(), \PHP_INT_MAX, false);
+            $this->connection->readAllEventsBackwardAsync(Position::start(), \PHP_INT_MAX, false);
         });
     }
 }

--- a/tests/read_all_events_forward_should.php
+++ b/tests/read_all_events_forward_should.php
@@ -186,7 +186,7 @@ class read_all_events_forward_should extends AsyncTestCase
         yield $this->execute(function (): Generator {
             $this->expectException(InvalidArgumentException::class);
 
-            yield $this->connection->readAllEventsForwardAsync(Position::start(), \PHP_INT_MAX, false);
+            $this->connection->readAllEventsForwardAsync(Position::start(), \PHP_INT_MAX, false);
         });
     }
 }

--- a/tests/read_event_stream_backward_should.php
+++ b/tests/read_event_stream_backward_should.php
@@ -247,7 +247,7 @@ class read_event_stream_backward_should extends EventStoreConnectionTestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        yield $this->connection->readStreamEventsBackwardAsync(
+        $this->connection->readStreamEventsBackwardAsync(
             'foo',
             StreamPosition::START,
             \PHP_INT_MAX,

--- a/tests/read_event_stream_forward_should.php
+++ b/tests/read_event_stream_forward_should.php
@@ -157,7 +157,7 @@ class read_event_stream_forward_should extends EventStoreConnectionTestCase
     {
         $this->expectException(InvalidArgumentException::class);
 
-        yield $this->connection->readStreamEventsForwardAsync(
+        $this->connection->readStreamEventsForwardAsync(
             'foo',
             StreamPosition::START,
             \PHP_INT_MAX,

--- a/tests/when_a_partitioned_projection_is_running.php
+++ b/tests/when_a_partitioned_projection_is_running.php
@@ -1,5 +1,14 @@
 <?php
 
+/**
+ * This file is part of `prooph/event-store-client`.
+ * (c) 2018-2020 Alexander Miertsch <kontakt@codeliner.ws>
+ * (c) 2018-2020 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
 declare(strict_types=1);
 
 namespace ProophTest\EventStoreClient;
@@ -65,5 +74,4 @@ final class when_a_partitioned_projection_is_running extends AsyncTestCase
             $this->assertNotEmpty($result->payload());
         });
     }
-
 }

--- a/tests/when_a_projection_is_running.php
+++ b/tests/when_a_projection_is_running.php
@@ -15,8 +15,8 @@ namespace ProophTest\EventStoreClient;
 
 use Amp\PHPUnit\AsyncTestCase;
 use Generator;
-use Prooph\EventStore\Projections\State;
 use Prooph\EventStore\Projections\Query;
+use Prooph\EventStore\Projections\State;
 use Prooph\EventStore\Util\Guid;
 
 class when_a_projection_is_running extends AsyncTestCase
@@ -85,7 +85,7 @@ class when_a_projection_is_running extends AsyncTestCase
                 $this->credentials
             );
 
-            $expectedResult = new State(1);
+            $expectedResult = new State(['count' => 1]);
 
             $this->assertEquals($expectedResult, $result);
         });


### PR DESCRIPTION
resolves #141
- setting httpSchema with constructor parameter for clients and managers
- setting httpSchema in client constructor makes this parameter in public methods redundant
- additionally fixing test after projections state fix made via 157d763