### PR TITLE
Catch Exception instead of Throwable

### DIFF
--- a/src/ClientOperations/AbstractOperation.php
+++ b/src/ClientOperations/AbstractOperation.php
@@ -15,6 +15,7 @@ namespace Prooph\EventStoreClient\ClientOperations;
 
 use Amp\Deferred;
 use Amp\Promise;
+use Exception;
 use Google\Protobuf\Internal\Message;
 use Prooph\EventStore\EndPoint;
 use Prooph\EventStore\Exception\NotAuthenticated;
@@ -127,7 +128,7 @@ abstract class AbstractOperation implements ClientOperation
     {
         try {
             $result = $this->transformResponse($response);
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             $this->deferred->fail($e);
 
             return;

--- a/src/ClientOperations/AbstractSubscriptionOperation.php
+++ b/src/ClientOperations/AbstractSubscriptionOperation.php
@@ -93,6 +93,7 @@ abstract class AbstractSubscriptionOperation implements SubscriptionOperation
     {
         $connection = ($this->getConnection)();
 
+        // In rare case the connection can be null. It is race condition where the connection was just closed.
         if (null !== $connection) {
             $connection->enqueueSend($package);
         }

--- a/src/ClientOperations/AbstractSubscriptionOperation.php
+++ b/src/ClientOperations/AbstractSubscriptionOperation.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\ClientOperations;
 
-use Exception;
 use function Amp\call;
 use Amp\Deferred;
 use Amp\Loop;
 use Amp\Promise;
 use Amp\Success;
 use Closure;
+use Exception;
 use Generator;
 use Prooph\EventStore\EndPoint;
 use Prooph\EventStore\EventStoreSubscription;
@@ -91,7 +91,11 @@ abstract class AbstractSubscriptionOperation implements SubscriptionOperation
 
     protected function enqueueSend(TcpPackage $package): void
     {
-        ($this->getConnection)()->enqueueSend($package);
+        $connection = ($this->getConnection)();
+
+        if (null !== $connection) {
+            $connection->enqueueSend($package);
+        }
     }
 
     public function subscribe(string $correlationId, TcpPackageConnection $connection): bool

--- a/src/ClientOperations/AbstractSubscriptionOperation.php
+++ b/src/ClientOperations/AbstractSubscriptionOperation.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\ClientOperations;
 
+use Exception;
 use function Amp\call;
 use Amp\Deferred;
 use Amp\Loop;
@@ -357,7 +358,7 @@ abstract class AbstractSubscriptionOperation implements SubscriptionOperation
         $this->actionQueue->enqueue($action);
 
         if ($this->actionQueue->count() > $this->maxQueueSize) {
-            $this->dropSubscription(SubscriptionDropReason::userInitiated(), new \Exception('client buffer too big'));
+            $this->dropSubscription(SubscriptionDropReason::userInitiated(), new Exception('client buffer too big'));
         }
 
         Loop::defer(function (): Generator {
@@ -375,7 +376,7 @@ abstract class AbstractSubscriptionOperation implements SubscriptionOperation
 
                 try {
                     yield $action();
-                } catch (Throwable $exception) {
+                } catch (Exception $exception) {
                     $this->log->error(\sprintf(
                         'Exception during executing user callback: %s', $exception->getMessage()
                     ));

--- a/src/Internal/ClusterDnsEndPointDiscoverer.php
+++ b/src/Internal/ClusterDnsEndPointDiscoverer.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
-use Exception;
 use function Amp\call;
 use Amp\Delayed;
 use Amp\Http\Client\HttpClient;
@@ -23,6 +22,7 @@ use Amp\Http\Client\Request;
 use Amp\Http\Client\Response;
 use Amp\Promise;
 use Amp\Success;
+use Exception;
 use Generator;
 use Prooph\EventStore\EndPoint;
 use Prooph\EventStore\Util\Json;
@@ -32,7 +32,6 @@ use Prooph\EventStoreClient\Messages\ClusterMessages\ClusterInfoDto;
 use Prooph\EventStoreClient\Messages\ClusterMessages\MemberInfoDto;
 use Prooph\EventStoreClient\Messages\ClusterMessages\VNodeState;
 use Psr\Log\LoggerInterface as Logger;
-use Throwable;
 
 /** @internal */
 final class ClusterDnsEndPointDiscoverer implements EndPointDiscoverer

--- a/src/Internal/ClusterDnsEndPointDiscoverer.php
+++ b/src/Internal/ClusterDnsEndPointDiscoverer.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
+use Exception;
 use function Amp\call;
 use Amp\Delayed;
 use Amp\Http\Client\HttpClient;
@@ -97,7 +98,7 @@ final class ClusterDnsEndPointDiscoverer implements EndPointDiscoverer
 
                         return new Success($endPoints);
                     }
-                } catch (Throwable $e) {
+                } catch (Exception $e) {
                     $this->log->info(\sprintf(
                         'Discovering attempt %d/%d failed with error: %s',
                         $attempt,
@@ -233,7 +234,7 @@ final class ClusterDnsEndPointDiscoverer implements EndPointDiscoverer
 
                 $response = yield $this->httpClient->request($request);
                 \assert($response instanceof Response);
-            } catch (Throwable $e) {
+            } catch (Exception $e) {
                 return;
             }
 

--- a/src/Internal/EventStoreAllCatchUpSubscription.php
+++ b/src/Internal/EventStoreAllCatchUpSubscription.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
-use Exception;
 use function Amp\call;
 use Amp\Delayed;
 use Amp\Promise;
 use Closure;
+use Exception;
 use Prooph\EventStore\AllEventsSlice;
 use Prooph\EventStore\Async\EventStoreAllCatchUpSubscription as AsyncEventStoreAllCatchUpSubscription;
 use Prooph\EventStore\Async\EventStoreConnection;

--- a/src/Internal/EventStoreAllCatchUpSubscription.php
+++ b/src/Internal/EventStoreAllCatchUpSubscription.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
+use Exception;
 use function Amp\call;
 use Amp\Delayed;
 use Amp\Promise;
@@ -158,7 +159,7 @@ class EventStoreAllCatchUpSubscription extends EventStoreCatchUpSubscription imp
             if ($e->originalPosition()->greater($this->lastProcessedPosition)) {
                 try {
                     yield ($this->eventAppeared)($this, $e);
-                } catch (Throwable $ex) {
+                } catch (Exception $ex) {
                     $this->dropSubscription(SubscriptionDropReason::eventHandlerException(), $ex);
                 }
 

--- a/src/Internal/EventStoreCatchUpSubscription.php
+++ b/src/Internal/EventStoreCatchUpSubscription.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
+use Exception;
 use function Amp\call;
 use Amp\Deferred;
 use Amp\Loop;
@@ -227,7 +228,7 @@ abstract class EventStoreCatchUpSubscription implements AsyncEventStoreCatchUpSu
                 try {
                     yield $this->readEventsTillAsync($this->connection, $this->resolveLinkTos, $this->userCredentials, null, null);
                     yield $this->subscribeToStreamAsync();
-                } catch (Throwable $ex) {
+                } catch (Exception $ex) {
                     $this->dropSubscription(SubscriptionDropReason::catchUpError(), $ex);
 
                     throw $ex;
@@ -438,7 +439,7 @@ abstract class EventStoreCatchUpSubscription implements AsyncEventStoreCatchUpSu
 
                     try {
                         yield $this->tryProcessAsync($e);
-                    } catch (Throwable $ex) {
+                    } catch (Exception $ex) {
                         $this->log->debug(\sprintf(
                             'Catch-up Subscription %s to %s: Exception occurred in subscription %s',
                             $this->subscriptionName,

--- a/src/Internal/EventStoreCatchUpSubscription.php
+++ b/src/Internal/EventStoreCatchUpSubscription.php
@@ -13,13 +13,13 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
-use Exception;
 use function Amp\call;
 use Amp\Deferred;
 use Amp\Loop;
 use Amp\Promise;
 use Amp\Success;
 use Closure;
+use Exception;
 use Generator;
 use Prooph\EventStore\Async\ClientConnectionEventArgs;
 use Prooph\EventStore\Async\EventStoreCatchUpSubscription as AsyncEventStoreCatchUpSubscription;

--- a/src/Internal/EventStorePersistentSubscription.php
+++ b/src/Internal/EventStorePersistentSubscription.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
-use Exception;
 use function Amp\call;
 use Amp\Deferred;
 use Amp\Delayed;
@@ -21,6 +20,7 @@ use Amp\Loop;
 use Amp\Promise;
 use Amp\Success;
 use Closure;
+use Exception;
 use Generator;
 use Prooph\EventStore\Async\EventStorePersistentSubscription as AsyncEventStorePersistentSubscription;
 use Prooph\EventStore\EventId;

--- a/src/Internal/EventStorePersistentSubscription.php
+++ b/src/Internal/EventStorePersistentSubscription.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
+use Exception;
 use function Amp\call;
 use Amp\Deferred;
 use Amp\Delayed;
@@ -383,7 +384,7 @@ class EventStorePersistentSubscription implements AsyncEventStorePersistentSubsc
                                     $e->event()->originalEventNumber()
                                 ));
                             }
-                        } catch (Throwable $ex) {
+                        } catch (Exception $ex) {
                             //TODO GFY should we autonak here?
 
                             $this->dropSubscription(SubscriptionDropReason::eventHandlerException(), $ex);

--- a/src/Internal/EventStoreStreamCatchUpSubscription.php
+++ b/src/Internal/EventStoreStreamCatchUpSubscription.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
+use Exception;
 use function Amp\call;
 use Amp\Delayed;
 use Amp\Promise;
@@ -177,7 +178,7 @@ class EventStoreStreamCatchUpSubscription extends EventStoreCatchUpSubscription 
             if ($e->originalEventNumber() > $this->lastProcessedEventNumber) {
                 try {
                     yield ($this->eventAppeared)($this, $e);
-                } catch (Throwable $ex) {
+                } catch (Exception $ex) {
                     $this->dropSubscription(SubscriptionDropReason::eventHandlerException(), $ex);
                 }
 

--- a/src/Internal/EventStoreStreamCatchUpSubscription.php
+++ b/src/Internal/EventStoreStreamCatchUpSubscription.php
@@ -13,11 +13,11 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
-use Exception;
 use function Amp\call;
 use Amp\Delayed;
 use Amp\Promise;
 use Closure;
+use Exception;
 use Generator;
 use Prooph\EventStore\Async\EventStoreConnection;
 use Prooph\EventStore\Async\EventStoreStreamCatchUpSubscription as AsyncEventStoreStreamCatchUpSubscription;

--- a/src/Transport/Tcp/TcpPackageConnection.php
+++ b/src/Transport/Tcp/TcpPackageConnection.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Transport\Tcp;
 
-use Exception;
 use function Amp\call;
 use Amp\Loop;
 use Amp\Promise;
@@ -23,13 +22,13 @@ use Amp\Socket\ConnectContext;
 use Amp\Socket\ConnectException;
 use Amp\Socket\EncryptableSocket;
 use Closure;
+use Exception;
 use Generator;
 use Prooph\EventStore\EndPoint;
 use Prooph\EventStore\Exception\InvalidArgumentException;
 use Prooph\EventStoreClient\Exception\PackageFramingException;
 use Prooph\EventStoreClient\SystemData\TcpPackage;
 use Psr\Log\LoggerInterface as Logger;
-use Throwable;
 
 /** @internal */
 class TcpPackageConnection

--- a/src/Transport/Tcp/TcpPackageConnection.php
+++ b/src/Transport/Tcp/TcpPackageConnection.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Transport\Tcp;
 
+use Exception;
 use function Amp\call;
 use Amp\Loop;
 use Amp\Promise;
@@ -137,7 +138,7 @@ class TcpPackageConnection
                     $e->getMessage()
                 ));
                 ($this->connectionClosed)($this, $e);
-            } catch (Throwable $e) {
+            } catch (Exception $e) {
                 $this->isClosed = true;
                 $this->log->debug(\sprintf(
                     'TcpPackageConnection: connection [%s, %s] was closed with error %s',
@@ -165,7 +166,7 @@ class TcpPackageConnection
                 \assert(null !== $this->connection);
 
                 yield $this->connection->write($package->asBytes());
-            } catch (Throwable $e) {
+            } catch (Exception $e) {
                 ($this->connectionClosed)($this, $e);
             }
         });
@@ -177,7 +178,7 @@ class TcpPackageConnection
 
         try {
             ($this->handlePackage)($this, $package);
-        } catch (Throwable $e) {
+        } catch (Exception $e) {
             \assert(null !== $this->connection);
 
             $this->connection->close();

--- a/tests/catch_up_subscription_handles_errors.php
+++ b/tests/catch_up_subscription_handles_errors.php
@@ -97,7 +97,11 @@ class catch_up_subscription_handles_errors extends AsyncTestCase
                 ResolvedEvent $resolvedEvent
             ) use (&$props1): Promise {
                 $props1['raisedEvents'][] = $resolvedEvent;
-                $props1['raisedEventEvent']->resolve(true);
+                try {
+                    $props1['raisedEventEvent']->resolve(true);
+                } catch (Throwable $e) {
+                    // on connection close this event may appear twice, just ignore second occurrence
+                }
 
                 return new Success();
             },


### PR DESCRIPTION
When trying this lib together with amphp v3 I ran into a problem where a type error of passing a wrong argument somewhere was completely hidden and the test failed with simple "Connection closed" exception with no further indication of what went wrong.

After a while I found out that the type error was caught [here](https://github.com/prooph/event-store-client/blob/a5c72910c6072fc08f4eb92b9550e0b5c3157c2e/src/Transport/Tcp/TcpPackageConnection.php#L140) and completely hidden by this library's error handling. In my opinion it's better to not catch `ErrorException` - those tend to be real bugs that you want to see right away.

Personally I'd be much more careful with catching `Exception` as well but that would require more knowledge.