### PR TITLE
StopWatch in seconds + VNodeState string backed enum

### DIFF
--- a/src/ConnectionSettingsBuilder.php
+++ b/src/ConnectionSettingsBuilder.php
@@ -231,7 +231,7 @@ class ConnectionSettingsBuilder
         return $this;
     }
 
-    public function setOperationTimeoutTo(int $operationTimeout): self
+    public function setOperationTimeoutTo(float $operationTimeout): self
     {
         if ($operationTimeout < 0) {
             throw new InvalidArgumentException('Timeout must be positive');
@@ -242,7 +242,7 @@ class ConnectionSettingsBuilder
         return $this;
     }
 
-    public function setTimeoutCheckPeriodTo(int $timeoutCheckPeriod): self
+    public function setTimeoutCheckPeriodTo(float $timeoutCheckPeriod): self
     {
         if ($timeoutCheckPeriod < 0) {
             throw new InvalidArgumentException('Timeout must be positive');
@@ -280,7 +280,7 @@ class ConnectionSettingsBuilder
         return $this;
     }
 
-    public function setHeartbeatInterval(int $interval): self
+    public function setHeartbeatInterval(float $interval): self
     {
         if ($interval < 0) {
             throw new InvalidArgumentException('Interval must be positive');

--- a/src/Internal/AuthInfo.php
+++ b/src/Internal/AuthInfo.php
@@ -22,7 +22,7 @@ class AuthInfo
 {
     public function __construct(
         private readonly string $correlationId,
-        private readonly int $timestamp
+        private readonly float $timestamp
     ) {
     }
 
@@ -31,7 +31,7 @@ class AuthInfo
         return $this->correlationId;
     }
 
-    public function timestamp(): int
+    public function timestamp(): float
     {
         return $this->timestamp;
     }

--- a/src/Internal/ClusterDnsEndPointDiscoverer.php
+++ b/src/Internal/ClusterDnsEndPointDiscoverer.php
@@ -262,7 +262,7 @@ final class ClusterDnsEndPointDiscoverer implements EndPointDiscoverer
         $this->log->info(\sprintf(
             'Discovering: found best choice [%s, %s] (%s)',
             $normTcp,
-            null === $secTcp ? 'n/a' : (string) $secTcp,
+            null === $secTcp ? 'n/a' : $secTcp,
             $node->state()->name
         ));
 

--- a/src/Internal/ClusterDnsEndPointDiscoverer.php
+++ b/src/Internal/ClusterDnsEndPointDiscoverer.php
@@ -261,9 +261,9 @@ final class ClusterDnsEndPointDiscoverer implements EndPointDiscoverer
 
         $this->log->info(\sprintf(
             'Discovering: found best choice [%s, %s] (%s)',
-            (string) $normTcp,
+            $normTcp,
             null === $secTcp ? 'n/a' : (string) $secTcp,
-            (string) $node->state()
+            $node->state()->name
         ));
 
         return new NodeEndPoints($normTcp, $secTcp);

--- a/src/Internal/EventStoreCatchUpSubscription.php
+++ b/src/Internal/EventStoreCatchUpSubscription.php
@@ -485,7 +485,7 @@ abstract class EventStoreCatchUpSubscription implements EventStoreCatchUpSubscri
                 'Catch-up Subscription %s to %s: dropped subscription, reason: %s %s',
                 $this->subscriptionName,
                 $this->isSubscribedToAll ? self::AllStream : $this->streamId,
-                $reason->name(),
+                $reason->name,
                 null === $error ? '' : $error->getMessage()
             ));
         }

--- a/src/Internal/HeartbeatInfo.php
+++ b/src/Internal/HeartbeatInfo.php
@@ -23,7 +23,7 @@ class HeartbeatInfo
     public function __construct(
         private readonly int $lastPackageNumber,
         private readonly bool $isIntervalStage,
-        private readonly int $timestamp
+        private readonly float $timestamp
     ) {
     }
 
@@ -37,7 +37,7 @@ class HeartbeatInfo
         return $this->isIntervalStage;
     }
 
-    public function timestamp(): int
+    public function timestamp(): float
     {
         return $this->timestamp;
     }

--- a/src/Internal/IdentifyInfo.php
+++ b/src/Internal/IdentifyInfo.php
@@ -22,7 +22,7 @@ class IdentifyInfo
 {
     public function __construct(
         private readonly string $correlationId,
-        private readonly int $timestamp
+        private readonly float $timestamp
     ) {
     }
 
@@ -31,7 +31,7 @@ class IdentifyInfo
         return $this->correlationId;
     }
 
-    public function timestamp(): int
+    public function timestamp(): float
     {
         return $this->timestamp;
     }

--- a/src/Internal/ReconnectionInfo.php
+++ b/src/Internal/ReconnectionInfo.php
@@ -22,7 +22,7 @@ class ReconnectionInfo
 {
     public function __construct(
         private readonly int $reconnectionAttempt,
-        private readonly int $timestamp
+        private readonly float $timestamp
     ) {
     }
 
@@ -31,7 +31,7 @@ class ReconnectionInfo
         return $this->reconnectionAttempt;
     }
 
-    public function timestamp(): int
+    public function timestamp(): float
     {
         return $this->timestamp;
     }

--- a/src/Internal/StopWatch.php
+++ b/src/Internal/StopWatch.php
@@ -13,27 +13,23 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
-use Prooph\EventStore\Util\DateTime;
-
 /** @internal */
 class StopWatch
 {
-    private function __construct(private readonly int $started)
+    private function __construct(private readonly float $started)
     {
     }
 
     public static function startNew(): self
     {
-        $now = DateTime::utcNow();
-        $started = (int) \floor((float) $now->format('U.u') * 1000);
+        $started = microtime(true);
 
         return new self($started);
     }
 
-    public function elapsed(): int
+    public function elapsed(): float
     {
-        $now = DateTime::utcNow();
-        $timestamp = (int) \floor((float) $now->format('U.u') * 1000);
+        $timestamp = microtime(true);;
 
         return $timestamp - $this->started;
     }

--- a/src/Messages/ClusterMessages/VNodeState.php
+++ b/src/Messages/ClusterMessages/VNodeState.php
@@ -13,23 +13,23 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Messages\ClusterMessages;
 
-enum VNodeState: int
+enum VNodeState: string
 {
-    case Initializing = 1;
-    case ReadOnlyLeaderless = 2;
-    case Unknown = 3;
-    case PreReadOnlyReplica = 4;
-    case PreReplica = 5;
-    case CatchingUp = 6;
-    case Clone = 7;
-    case ReadOnlyReplica = 8;
-    case Slave = 9;
-    case Follower = 10;
-    case PreMaster = 11;
-    case PreLeader = 12;
-    case Master = 13;
-    case Leader = 14;
-    case Manager = 15;
-    case ShuttingDown = 16;
-    case Shutdown = 17;
+    case Initializing = 'Initializing';
+    case ReadOnlyLeaderless = 'ReadOnlyLeaderless';
+    case Unknown = 'Unknown';
+    case PreReadOnlyReplica = 'PreReadOnlyReplica';
+    case PreReplica = 'PreReplica';
+    case CatchingUp = 'CatchingUp';
+    case Clone = 'Clone';
+    case ReadOnlyReplica = 'ReadOnlyReplica';
+    case Slave = 'Slave';
+    case Follower = 'Follower';
+    case PreMaster = 'PreMaster';
+    case PreLeader = 'PreLeader';
+    case Master = 'Master';
+    case Leader = 'Leader';
+    case Manager = 'Manager';
+    case ShuttingDown = 'ShuttingDown';
+    case Shutdown = 'Shutdown';
 }


### PR DESCRIPTION

1. Connecting to a cluster does not work, the node state returned from the server is a string, so either we need VNodeState to be a string backed enum (as suggested in this PR) or a custom factory needs to be created, if keeping the integers is important. 

2. In the new amp v3 version, timeouts/intervals in the connection settings are configured in seconds (floats) rather than milliseconds. This PR changes the stopwatch to return a float (in seconds) instead of an int (in milliseconds)
