### PR TITLE
Use float seconds for timestamps and stopwatch

### DIFF
--- a/src/ClientOperations/ReadAllEventsBackwardOperation.php
+++ b/src/ClientOperations/ReadAllEventsBackwardOperation.php
@@ -83,8 +83,7 @@ class ReadAllEventsBackwardOperation extends AbstractOperation
                 $this->fail(new ServerError($response->getError()));
 
                 return new InspectionResult(InspectionDecision::EndOperation, 'Error');
-            case
-            ReadAllResult::AccessDenied:
+            case ReadAllResult::AccessDenied:
                 $this->fail(AccessDenied::toAllStream());
 
                 return new InspectionResult(InspectionDecision::EndOperation, 'AccessDenied');

--- a/src/Internal/StopWatch.php
+++ b/src/Internal/StopWatch.php
@@ -13,8 +13,6 @@ declare(strict_types=1);
 
 namespace Prooph\EventStoreClient\Internal;
 
-use Prooph\EventStore\Util\DateTime;
-
 /** @internal */
 class StopWatch
 {
@@ -24,14 +22,14 @@ class StopWatch
 
     public static function startNew(): self
     {
-        $started = microtime(true);
+        $started = \microtime(true);
 
         return new self($started);
     }
 
     public function elapsed(): float
     {
-        $timestamp = microtime(true);;
+        $timestamp = \microtime(true);
 
         return $timestamp - $this->started;
     }

--- a/src/Internal/StopWatch.php
+++ b/src/Internal/StopWatch.php
@@ -18,22 +18,20 @@ use Prooph\EventStore\Util\DateTime;
 /** @internal */
 class StopWatch
 {
-    private function __construct(private readonly int $started)
+    private function __construct(private readonly float $started)
     {
     }
 
     public static function startNew(): self
     {
-        $now = DateTime::utcNow();
-        $started = (int) \floor((float) $now->format('U.u') * 1000);
+        $started = microtime(true);
 
         return new self($started);
     }
 
-    public function elapsed(): int
+    public function elapsed(): float
     {
-        $now = DateTime::utcNow();
-        $timestamp = (int) \floor((float) $now->format('U.u') * 1000);
+        $timestamp = microtime(true);;
 
         return $timestamp - $this->started;
     }


### PR DESCRIPTION
Use float seconds for timestamps and stopwatch as per how the connection settings are configured.

This is the code by @grymmare from #170 that was previously merged in and then reverted (mistakenly?) in #176