### PR TITLE
Fix Event loop terminated without resuming the current suspension

### DIFF
--- a/src/Internal/EventStoreConnectionLogicHandler.php
+++ b/src/Internal/EventStoreConnectionLogicHandler.php
@@ -204,7 +204,6 @@ class EventStoreConnectionLogicHandler
                 $this->timerTickWatcherId = EventLoop::repeat(Consts::TimerPeriod, function (): void {
                     $this->timerTick();
                 });
-                EventLoop::unreference($this->timerTickWatcherId);
 
                 $this->endPointDiscoverer = $endPointDiscoverer;
                 $this->state = ConnectionState::Connecting;


### PR DESCRIPTION
No need to unreference timerTick, it should be executed as long as EventLoop is running.
